### PR TITLE
fix(tooltip): :bug: difficult to read tooltip content

### DIFF
--- a/src/components/DeploymentCell.tsx
+++ b/src/components/DeploymentCell.tsx
@@ -76,7 +76,10 @@ export function DeploymentCell({
                   </span>
                 </Link>
               </TooltipTrigger>
-              <TooltipContent side="top">
+              <TooltipContent
+                side="top"
+                className="bg-popover text-popover-foreground border-border animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 z-50 rounded-md border px-3 py-1.5 text-sm shadow-md"
+              >
                 <p>Branch: {deployment.ref}</p>
               </TooltipContent>
             </Tooltip>
@@ -107,7 +110,10 @@ export function DeploymentCell({
                       </span>
                     </Link>
                   </TooltipTrigger>
-                  <TooltipContent side="top">
+                  <TooltipContent
+                    side="top"
+                    className="bg-popover text-popover-foreground border-border animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 z-50 rounded-md border px-3 py-1.5 text-sm shadow-md"
+                  >
                     <p>Release: {deployment.release.name}</p>
                   </TooltipContent>
                 </Tooltip>
@@ -135,7 +141,10 @@ export function DeploymentCell({
                 <span className="font-mono">{deployment.sha}</span>
               </Link>
             </TooltipTrigger>
-            <TooltipContent side="top">
+            <TooltipContent
+              side="top"
+              className="bg-popover text-popover-foreground border-border animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 z-50 rounded-md border px-3 py-1.5 text-sm shadow-md"
+            >
               <p>Commit: {deployment.sha}</p>
             </TooltipContent>
           </Tooltip>
@@ -179,7 +188,10 @@ export function DeploymentCell({
                     </span>
                   </Link>
                 </TooltipTrigger>
-                <TooltipContent side="top">
+                <TooltipContent
+                  side="top"
+                  className="bg-popover text-popover-foreground border-border animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 z-50 rounded-md border px-3 py-1.5 text-sm shadow-md"
+                >
                   <p>Deployed by {deployment.actor.login}</p>
                 </TooltipContent>
               </Tooltip>


### PR DESCRIPTION
<img width="567" alt="image" src="https://github.com/user-attachments/assets/848af65f-8a02-4a9d-8401-c1d422158561" />
<!--- START AUTOGENERATED NOTES --->
### Changelog ([#148](https://github.com/ZuCommunications/dependency-tracker/pull/148))

#### 🐛 Bug Fixes
- (tooltip) :bug: difficult to read tooltip content

<!--- END AUTOGENERATED NOTES --->